### PR TITLE
Fix scraper, reduce speed

### DIFF
--- a/listscraper/scrape_functions.py
+++ b/listscraper/scrape_functions.py
@@ -1,7 +1,7 @@
-from listscraper.utility_functions import val2stars, stars2val
+from listscraper.utility_functions import val2stars, stars2val, repeated_request
 from bs4 import BeautifulSoup
 from tqdm import tqdm
-import requests
+#import requests
 import numpy as np
 import re
 
@@ -70,7 +70,7 @@ def scrape_page(list_url, og_list_url, output_file_extension, list_type, quiet=F
     """
     
     page_films = []
-    page_response = requests.get(list_url)
+    page_response = repeated_request(list_url)
     
     # Check to see page was downloaded correctly
     if page_response.status_code != 200:
@@ -125,9 +125,7 @@ def scrape_film(film_html, not_found):
     # Obtaining release year, director and average rating of the movie
     film_card = film_html.find('div').get('data-target-link')[1:]
     film_url = _domain + film_card
-    filmget = requests.get(film_url)
-    if filmget.status_code == 429:
-        print("Server returned code 429 for spamming requests too quickly.")
+    filmget = repeated_request(film_url)
     film_soup = BeautifulSoup(filmget.content, 'html.parser')
 
     # Finding the film name
@@ -236,7 +234,7 @@ def scrape_film(film_html, not_found):
 
     # Getting number of watches, appearances in lists and number of likes (requires new link) ## 
     movie = film_url.split('/')[-2]                                        # Movie title in URL
-    r = requests.get(f'https://letterboxd.com/csi/film/{movie}/stats/')    # Stats page of said movie
+    r = repeated_request(f'https://letterboxd.com/csi/film/{movie}/stats/')    # Stats page of said movie
     stats_soup = BeautifulSoup(r.content, 'lxml')
 
     tooltips = stats_soup.find_all('a', {'class': 'tooltip'})
@@ -257,7 +255,7 @@ def scrape_film(film_html, not_found):
     film_dict["Likes"] = int(''.join(likes))
 
     # Getting info on rating histogram (requires new link)
-    r = requests.get(f'https://letterboxd.com/csi/film/{movie}/rating-histogram/')    # Rating histogram page of said movie
+    r = repeated_request(f'https://letterboxd.com/csi/film/{movie}/rating-histogram/')    # Rating histogram page of said movie
     hist_soup = BeautifulSoup(r.content, 'lxml')
 
     # Get number of fans. Amount is given in 'K' notation, so if relevant rounded off to full thousands

--- a/listscraper/scrape_functions.py
+++ b/listscraper/scrape_functions.py
@@ -126,6 +126,8 @@ def scrape_film(film_html, not_found):
     film_card = film_html.find('div').get('data-target-link')[1:]
     film_url = _domain + film_card
     filmget = requests.get(film_url)
+    if filmget.status_code == 429:
+        print("Server returned code 429 for spamming requests too quickly.")
     film_soup = BeautifulSoup(filmget.content, 'html.parser')
 
     # Finding the film name

--- a/listscraper/scrape_functions.py
+++ b/listscraper/scrape_functions.py
@@ -1,7 +1,6 @@
 from listscraper.utility_functions import val2stars, stars2val, repeated_request
 from bs4 import BeautifulSoup
 from tqdm import tqdm
-#import requests
 import numpy as np
 import re
 
@@ -133,9 +132,9 @@ def scrape_film(film_html, not_found):
     
     # Try to find release year, handle cases where it's missing
     try:
-        release_years = film_soup.find_all('div', class_='releaseyear')
-        if len(release_years) > 1:  # Check if we have enough elements
-            year_text = release_years[1].find('a').text.strip()
+        release_years = film_soup.find_all('span', class_='releasedate')
+        if len(release_years) > 0:  # Check if we have enough elements
+            year_text = release_years[0].find('a').text.strip()
             release_year = int(year_text) if year_text else 0
         else:
             release_year = 0

--- a/listscraper/scrape_functions.py
+++ b/listscraper/scrape_functions.py
@@ -237,18 +237,20 @@ def scrape_film(film_html, not_found):
     r = requests.get(f'https://letterboxd.com/csi/film/{movie}/stats/')    # Stats page of said movie
     stats_soup = BeautifulSoup(r.content, 'lxml')
 
+    tooltips = stats_soup.find_all('a', {'class': 'tooltip'})
+
     # Get number of people that have watched the movie
-    watches = stats_soup.find('a', {'class': 'has-icon icon-watched icon-16 tooltip'})["title"]
+    watches = tooltips[0]["title"]
     watches = re.findall(r'\d+', watches)    # Find the number from string
     film_dict["Watches"] = int(''.join(watches))          # Filter out commas from large numbers
 
     # Get number of film appearances in lists
-    list_appearances = stats_soup.find('a', {'class': 'has-icon icon-list icon-16 tooltip'})["title"]
+    list_appearances = tooltips[1]["title"]
     list_appearances = re.findall(r'\d+', list_appearances) 
     film_dict["List_appearances"] = int(''.join(list_appearances))
 
     # Get number of people that have liked the movie
-    likes = stats_soup.find('a', {'class': 'has-icon icon-like icon-liked icon-16 tooltip'})["title"]
+    likes = tooltips[2]["title"]
     likes = re.findall(r'\d+', likes)
     film_dict["Likes"] = int(''.join(likes))
 

--- a/listscraper/utility_functions.py
+++ b/listscraper/utility_functions.py
@@ -91,7 +91,8 @@ def repeated_request(url):
                 time.sleep(current_delay)
                 current_delay = min(current_delay * 2, max_delay)
             else:
-                #print("Max retries exceeded. Giving up.")
+                print("Max retries exceeded. Giving up.")
                 raise # Re-raise the last exception
 
+    print(f"Request failed after all retries. Server status code: {response.status_code}")
     raise requests.exceptions.RequestException(f"Request failed after all retries. Server status code: {response.status_code}")

--- a/listscraper/utility_functions.py
+++ b/listscraper/utility_functions.py
@@ -1,4 +1,6 @@
 # Some utility functions are stored here
+import requests
+import time
 
 def stars2val(stars, not_found):
     """
@@ -43,3 +45,53 @@ def val2stars(val, not_found):
         return stars
     except:
         return not_found
+
+def repeated_request(url):
+    """
+    Makes a request to a URL with exponential backoff for 429 errors.
+
+    Args:
+        url (str): The URL to make a request to.
+
+    Returns:
+        requests.Response: The successful response object.
+
+    Raises:
+        requests.exceptions.RequestException: If the request fails after all retries.
+    """
+    retries = 0
+    max_retries = 5
+    current_delay = 8
+    max_delay = 120  # 2 minutes in seconds
+
+    while retries < max_retries:
+        try:
+            response = requests.get(url)
+            
+            # Check for a 429 "Too Many Requests" error
+            if response.status_code == 429:
+                print(f"Received 429 response. Retrying in {current_delay} seconds...")
+                time.sleep(current_delay)
+                
+                # Double the delay for the next attempt, capped at max_delay
+                current_delay = min(current_delay * 2, max_delay)
+                retries += 1
+                continue  # Skip to the next iteration of the while loop
+            
+            # If the request is successful, or another error occurs, break the loop
+            response.raise_for_status()
+            #print("Request successful!")
+            return response
+            
+        except requests.exceptions.RequestException as e:
+            print(f"An error occurred during request: {e}")
+            retries += 1
+            if retries < max_retries:
+                print(f"Retrying in {current_delay} seconds...")
+                time.sleep(current_delay)
+                current_delay = min(current_delay * 2, max_delay)
+            else:
+                #print("Max retries exceeded. Giving up.")
+                raise # Re-raise the last exception
+
+    raise requests.exceptions.RequestException(f"Request failed after all retries. Server status code: {response.status_code}")

--- a/listscraper/utility_functions.py
+++ b/listscraper/utility_functions.py
@@ -51,7 +51,7 @@ def repeated_request(url):
     """
     Makes a request to a URL with a backoff for 429 errors.
 
-    Args:
+    Parameters:
         url (str): The URL to make a request to.
 
     Returns:
@@ -70,10 +70,9 @@ def repeated_request(url):
     while retry_index < len(retry_seconds):
         try:
             response = requests.get(url, headers=headers)
-            # Wait a random amount of seconds, with an average of about 1 second
-            wait_time = random.gauss(mu=1.0, sigma=1.0)
-            if wait_time < 0.3:
-                wait_time = 0.6 - wait_time
+            
+            # Wait a random amount of seconds, with an average of .75 seconds
+            wait_time = random.gauss(mu=0.75, sigma=0.08)
             time.sleep(wait_time)
             
             # Check for a 429 "Too Many Requests" error
@@ -87,7 +86,6 @@ def repeated_request(url):
             
             # If the request is successful, or another error occurs, break the loop
             response.raise_for_status()
-            #print("Request successful!")
             return response
             
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Fixes the following:
1. Critical bug preventing the scraper from working #24 #26 
2. Failing to grab the release year #25 
3. Failing under a 429 response from the server

It also prevents 429 responses from the server by setting a Firefox user agent and adding a random 1-second delay to each server request. The user agent is necessary, but I do not know if the delay is necessary. It slows down the processing speed, of course. You may remove the delay if you want, but I added it because Letterboxd clearly doesn't want bots scraping their data, and it further hides that this is a bot. Before the user agent change, I would get a 429 response every 2 films, with a 40 second timeout.

Tested working on my system through a VPN. [4.17s/it]